### PR TITLE
Conditionally apply latest Docker image tag

### DIFF
--- a/.github/workflows/deploy-build-image.yml
+++ b/.github/workflows/deploy-build-image.yml
@@ -87,7 +87,7 @@ jobs:
             type=ref,event=branch
             type=ref,event=pr
             type=sha
-            latest
+            type=raw,value=latest,enable={{is_default_branch}}
       - name: Build webapp image
         uses: docker/build-push-action@v2
         with:


### PR DESCRIPTION
Allows us to build and deploy to review apps without overwriting the "latest" tag.

Heroku deployments will remain isolated within the Heroku registry, so there is no chance of "overwriting" a production  or staging deploy.